### PR TITLE
fix(toast): Improve semantics

### DIFF
--- a/packages/toast/src/component.js
+++ b/packages/toast/src/component.js
@@ -53,14 +53,19 @@ export class FabricToast extends FabricWebComponent {
         const isWarning = this.type === 'warning';
         const isError = this.type === 'error';
         const isInfo = this.type === 'info';
+        const typeLabel = (
+            isSuccess ? 'Vellykket' :
+            isError   ? 'Feil' :
+            isWarning ? 'Varsel' :
+                        'Info'
+        );
 
         this.shadowRoot.innerHTML += `
-            <div
+            <section
                 ${this.id ? `id="toast-${this.id}-wrapper"` : ''}
                 ${isProgrammatic && !updated ? "style='height: 0;'" : ''}
                 class="${c.toastWrapper}"
-                role="status"
-                aria-live="polite"
+                aria-label="${typeLabel}"
             >
                 <div
                     class="${classNames({
@@ -84,6 +89,8 @@ export class FabricToast extends FabricWebComponent {
                             isSuccess
                                 ? `
                         <svg
+                            role="img"
+                            aria-label="${typeLabel}"
                             xmlns="http://www.w3.org/2000/svg"
                             width="16"
                             height="16"
@@ -100,6 +107,8 @@ export class FabricToast extends FabricWebComponent {
                         </svg>`
                                 : `
                         <svg
+                            role="img"
+                            aria-label="${typeLabel}"
                             xmlns="http://www.w3.org/2000/svg"
                             width="16"
                             height="16"
@@ -128,10 +137,13 @@ export class FabricToast extends FabricWebComponent {
                         </svg>`
                         }
                     </div>
-                    <div class="${c.toastContent}">
+                    <div
+                        role="${(isError || isWarning) ? 'alert' : 'status'}"
+                        class="${c.toastContent}"
+                    >
                         <p ${this.id ? `id="toast-${this.id}-text"` : ''}>${
-            this.text
-        }</p>
+                            this.text
+                        }</p>
                     </div>
                     ${
                         this.canclose
@@ -141,6 +153,8 @@ export class FabricToast extends FabricWebComponent {
                                 class="${c.toastClose}"
                             >
                                 <svg
+                                    role="img"
+                                    aria-label="Lukk"
                                     xmlns="http://www.w3.org/2000/svg"
                                     width="16"
                                     height="16"
@@ -158,7 +172,7 @@ export class FabricToast extends FabricWebComponent {
                             : ``
                     }
                 </div>
-            </div>
+            </section>
         `;
 
         if (

--- a/pages/components/toast.html
+++ b/pages/components/toast.html
@@ -12,14 +12,14 @@
                 text="Hi! I'm an example toast!"
             ></f-toast>
 
-            <h2>Error type</h2>
+            <h2 class="mt-20">Error type</h2>
             <f-toast
                 id="error"
                 type="error"
                 text="Hi! I'm an example error message!"
             ></f-toast>
 
-            <h2>Can close</h2>
+            <h2 class="mt-20">Can close</h2>
             <f-toast
                 id="canclose"
                 canclose

--- a/pages/components/toast.html
+++ b/pages/components/toast.html
@@ -5,10 +5,25 @@
         <main>
             <h1>&lt;f-toast&gt;</h1>
 
+            <h2>Success type</h2>
             <f-toast
-                id="test"
+                id="success"
                 type="success"
                 text="Hi! I'm an example toast!"
+            ></f-toast>
+
+            <h2>Error type</h2>
+            <f-toast
+                id="error"
+                type="error"
+                text="Hi! I'm an example error message!"
+            ></f-toast>
+
+            <h2>Can close</h2>
+            <f-toast
+                id="canclose"
+                canclose
+                text="Hi! I'm an example toast that can be dismissed! ... Maybe"
             ></f-toast>
         </main>
 

--- a/pages/includes/scripts.js
+++ b/pages/includes/scripts.js
@@ -1,7 +1,7 @@
 import { FabricBox } from '../../packages/box/src/fabric-box.js';
 import { FabricBreadcrumbs } from '../../packages/breadcrumbs/src/fabric-breadcrumbs.js';
 import { FabricModal } from '../../packages/modal/src/fabric-modal.js';
-import { toast, removeToast, updateToast } from '../../packages/toast/src/index.js';
+import '../../packages/toast/src/index.js';
 
 customElements.define('f-modal', FabricModal);
 customElements.define('f-box', FabricBox);


### PR DESCRIPTION
- Add more f-toast examples.
- Use alert role for errors and warnings, status role otherwise.
- Make sure only the text is part of alert/status.
- Wrap toast component in labelled section.
- Add labels to SVGs.
- Give accessible name to close button (via labelled SVG).