### PR TITLE
fix(select): fix docs path and invalid attributes

### DIFF
--- a/packages/select/index.js
+++ b/packages/select/index.js
@@ -19,9 +19,6 @@ export class FabricSelect extends kebabCaseAttributes(FabricElement) {
     // The content displayed as the help text
     hint: { type: String, reflect: true },
 
-    // The element's unique identifier
-    id: { type: String, reflect: true },
-
     // The content to disply as the label
     label: { type: String, reflect: true },
 

--- a/packages/select/index.js
+++ b/packages/select/index.js
@@ -70,7 +70,7 @@ export class FabricSelect extends kebabCaseAttributes(FabricElement) {
             id="${this.#id}"
             ?autofocus=${this.autoFocus}
             aria-describedby="${ifDefined(this.#helpId)}"
-            aria-invalid="${ifDefined(this.invalid && this.#helpId)}"
+            aria-invalid="${ifDefined(this.invalid)}"
             aria-errormessage="${ifDefined(this.invalid && this.#helpId)}"
           >
             ${unsafeHTML(this._options)}

--- a/packages/select/index.js
+++ b/packages/select/index.js
@@ -2,7 +2,7 @@ import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { when } from 'lit/directives/when.js';
 import { classNames } from '@chbphone55/classnames';
-import { kebabCaseAttributes, FabricElement, generateRandomId } from '../utils';
+import { kebabCaseAttributes, FabricElement } from '../utils';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 
 export class FabricSelect extends kebabCaseAttributes(FabricElement) {
@@ -38,7 +38,7 @@ export class FabricSelect extends kebabCaseAttributes(FabricElement) {
   }
 
   get #id() {
-    return this.id || generateRandomId();
+    return 'select_id';
   }
 
   get #helpId() {

--- a/pages/components/select.html
+++ b/pages/components/select.html
@@ -53,14 +53,6 @@
               <td></td>
             </tr>
             <tr>
-              <td>id</td>
-              <td>
-                <div>string</div>
-                <div class="annotation">The element's unique identifier</div>
-              </td>
-              <td></td>
-            </tr>
-            <tr>
               <td>label</td>
               <td>
                 <div>string</div>

--- a/pages/includes/nav.html
+++ b/pages/includes/nav.html
@@ -28,7 +28,7 @@
         "items": [
           {
             "title": "Select",
-            "href": "/pages/components/select.html"
+            "href": "select.html"
           },
           {
             "title": "Textfield",

--- a/tap-snapshots/packages/select/test.js.test.cjs
+++ b/tap-snapshots/packages/select/test.js.test.cjs
@@ -4,14 +4,12 @@
  * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
  * Make sure to inspect the output below.  Do not ignore changes!
  */
-'use strict';
-exports[
-  `packages/select/test.js TAP Select component with no attributes is rendered on the page > must match snapshot 1`
-] = `
+'use strict'
+exports[`packages/select/test.js TAP Select component with no attributes is rendered on the page > must match snapshot 1`] = `
 
       <option>First option</option>
       <option>Second option</option>
-`;
+`
 
 exports[`packages/select/test.js TAP Select renders label > must match snapshot 1`] = `
 <label for="withlabel">
@@ -26,12 +24,12 @@ exports[`packages/select/test.js TAP Select renders label > must match snapshot 
           </select>
         </div>
         
-`;
+`
 
 exports[`packages/select/test.js TAP Select renders with error > must match snapshot 1`] = `
 
         <div class="input--select__wrap">
-          <select id="hello" aria-describedby="hello__hint" aria-invalid="hello__hint" aria-errormessage="hello__hint">
+          <select id="hello" aria-describedby="hello__hint" aria-invalid="true" aria-errormessage="hello__hint">
             
           <option>First option</option>
           <option>Second option</option>
@@ -39,7 +37,7 @@ exports[`packages/select/test.js TAP Select renders with error > must match snap
           </select>
         </div>
         <div class="input__sub-text" id="hello__hint">Something went wrong</div>
-`;
+`
 
 exports[`packages/select/test.js TAP Select renders with hint > must match snapshot 1`] = `
 
@@ -52,4 +50,4 @@ exports[`packages/select/test.js TAP Select renders with hint > must match snaps
           </select>
         </div>
         <div class="input__sub-text" id="hello__hint">Hello</div>
-`;
+`

--- a/tap-snapshots/packages/select/test.js.test.cjs
+++ b/tap-snapshots/packages/select/test.js.test.cjs
@@ -12,11 +12,11 @@ exports[`packages/select/test.js TAP Select component with no attributes is rend
 `
 
 exports[`packages/select/test.js TAP Select renders label > must match snapshot 1`] = `
-<label for="withlabel">
+<label for="select_id">
               Options
               </label>
         <div class="input--select__wrap">
-          <select id="withlabel">
+          <select id="select_id">
             
       <option>First option</option>
       <option>Second option</option>
@@ -29,25 +29,25 @@ exports[`packages/select/test.js TAP Select renders label > must match snapshot 
 exports[`packages/select/test.js TAP Select renders with error > must match snapshot 1`] = `
 
         <div class="input--select__wrap">
-          <select id="hello" aria-describedby="hello__hint" aria-invalid="true" aria-errormessage="hello__hint">
+          <select id="select_id" aria-describedby="select_id__hint" aria-invalid="true" aria-errormessage="select_id__hint">
             
           <option>First option</option>
           <option>Second option</option>
         
           </select>
         </div>
-        <div class="input__sub-text" id="hello__hint">Something went wrong</div>
+        <div class="input__sub-text" id="select_id__hint">Something went wrong</div>
 `
 
 exports[`packages/select/test.js TAP Select renders with hint > must match snapshot 1`] = `
 
         <div class="input--select__wrap">
-          <select id="hello" aria-describedby="hello__hint">
+          <select id="select_id" aria-describedby="select_id__hint">
             
         <option>First option</option>
         <option>Second option</option>
       
           </select>
         </div>
-        <div class="input__sub-text" id="hello__hint">Hello</div>
+        <div class="input__sub-text" id="select_id__hint">Hello</div>
 `


### PR DESCRIPTION
- fixes path to `select.html` on the documentation page
- fixes `aria-invalid` attribute value
- sets correct `id`s on corresponding elements