### PR TITLE
fix: log actual errors in broadcast requests

### DIFF
--- a/packages/broadcast/component.js
+++ b/packages/broadcast/component.js
@@ -51,7 +51,7 @@ export class FabricBroadcast extends LitElement {
       const res = await (await fetch(url)).json();
       this._messages = res.length ? res : [];
     } catch (err) {
-      console.error(`failed to fetch broadcasts from given url (${url})`);
+      console.error(`failed to fetch broadcasts from given url (${url})`, err);
     }
   }
 


### PR DESCRIPTION
Some rogue errors which might just be due to offline browsers are showing up in trackjs and we need to diagnose. This PR logs the actual error to make that easier.